### PR TITLE
use base_path to reference route files

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,10 +4,12 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
+use function base_path;
+
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: base_path('routes/web.php'),
+        commands: base_path('routes/console.php'),
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {


### PR DESCRIPTION
It makes sense to me to use the `base_path` function to point towards the route files. The syntax seems cleaner than using relative paths and string concatenation.